### PR TITLE
feat: 为 code-cli 增加 ops 运维工具镜像

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ git diff
 
 ## code-cli 容器
 
-`docker_files/code-cli` 提供 `core`、`python`、`rust` 和 `go` 四种镜像。构建方式、平台支持和验证命令见 [code-cli 文档](docker_files/code-cli/README.md)。
+`docker_files/code-cli` 提供 `core`、`python`、`rust`、`go` 和 `ops` 五种镜像。`ops` 包含数据库客户端与网络排障工具；构建方式、平台支持和验证命令见 [code-cli 文档](docker_files/code-cli/README.md)。
 
 ## License
 

--- a/docker_files/code-cli/Dockerfile
+++ b/docker_files/code-cli/Dockerfile
@@ -88,6 +88,12 @@ FROM ${ALPINE_IMAGE}
 
 ARG CODE_CLI_VARIANT=core
 ARG TARGETARCH
+ARG KAF_VERSION=0.2.14
+ARG KAF_SHA256_AMD64=c2cc6e412d31f979242e3c7ca38f8474402c3722ef0ced22f842fe2a74818889
+ARG KAF_SHA256_ARM64=8bcb6738652088f1b3d59ff4d244f5e5ce5ae0ae29c6e7caa6b255abd828d97d
+ARG TRIPPY_VERSION=0.13.0
+ARG TRIPPY_SHA256_AMD64=aa2b7b2a0773f3cc04da691100419049950b690fe3736d25e24ac955b63d6056
+ARG TRIPPY_SHA256_ARM64=73af939aa94e9e0f07cac2b3c8177e02a6b1c3be88299d85988e02be81ae7004
 
 ENV HOME=/root \
     LANG=C.UTF-8 \
@@ -105,7 +111,7 @@ RUN set -eux; \
       return 1; \
     }; \
     case "${CODE_CLI_VARIANT}" in \
-      core|python|rust|go) ;; \
+      core|python|rust|go|ops) ;; \
       *) echo "unsupported CODE_CLI_VARIANT: ${CODE_CLI_VARIANT}" >&2; exit 1 ;; \
     esac; \
     apk_add_with_retry \
@@ -123,6 +129,73 @@ RUN set -eux; \
       python) apk_add_with_retry python3 py3-pip py3-pynvim ;; \
       rust) apk_add_with_retry cargo rust ;; \
       go) apk_add_with_retry go ;; \
+      ops) \
+        apk_add_with_retry \
+          bind-tools \
+          iproute2 \
+          iputils \
+          jq \
+          kcat \
+          mtr \
+          nmap \
+          nmap-ncat \
+          openssh-client \
+          openssl \
+          pgcli \
+          postgresql-client \
+          py3-pip \
+          redis \
+          socat \
+          xh \
+          yq; \
+        case "${TARGETARCH}" in \
+          amd64) \
+            kaf_arch=x86_64; \
+            kaf_sha256="${KAF_SHA256_AMD64}"; \
+            trippy_arch=x86_64; \
+            trippy_sha256="${TRIPPY_SHA256_AMD64}" ;; \
+          arm64) \
+            kaf_arch=arm64; \
+            kaf_sha256="${KAF_SHA256_ARM64}"; \
+            trippy_arch=aarch64; \
+            trippy_sha256="${TRIPPY_SHA256_ARM64}" ;; \
+          *) echo "unsupported ops TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+        esac; \
+        workdir="$(mktemp -d)"; \
+        curl -fsSL --retry 3 --retry-all-errors \
+          "https://github.com/birdayz/kaf/releases/download/v${KAF_VERSION}/kaf_${KAF_VERSION}_Linux_${kaf_arch}.tar.gz" \
+          -o "${workdir}/kaf.tar.gz"; \
+        echo "${kaf_sha256}  ${workdir}/kaf.tar.gz" | sha256sum -c -; \
+        tar -xzf "${workdir}/kaf.tar.gz" -C "${workdir}" kaf; \
+        install -m 0755 "${workdir}/kaf" /usr/local/bin/kaf; \
+        curl -fsSL --retry 3 --retry-all-errors \
+          "https://github.com/fujiapple852/trippy/releases/download/${TRIPPY_VERSION}/trippy-${TRIPPY_VERSION}-${trippy_arch}-unknown-linux-musl.tar.gz" \
+          -o "${workdir}/trippy.tar.gz"; \
+        echo "${trippy_sha256}  ${workdir}/trippy.tar.gz" | sha256sum -c -; \
+        tar -xzf "${workdir}/trippy.tar.gz" -C "${workdir}"; \
+        install -m 0755 \
+          "${workdir}/trippy-${TRIPPY_VERSION}-${trippy_arch}-unknown-linux-musl/trip" \
+          /usr/local/bin/trip; \
+        printf '%s\n' \
+          'iredis==1.16.0 --hash=sha256:8b51086e5cae9e3d136a74cd9b35c5b75491dcb333d2dae476078094df4cc5d2' \
+          'click==8.4.2 --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76' \
+          'configobj==5.0.9 --hash=sha256:1ba10c5b6ee16229c79a05047aeda2b55eb4e80d7c7d8ecf17ec1ca600c79882' \
+          'mistune==3.3.3 --hash=sha256:99de1585e42dcbd826faa9e11a202727a5e202e4e4722a4c69ac1ff615793dd7' \
+          'packaging==24.2 --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759' \
+          'prompt_toolkit==3.0.52 --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955' \
+          'Pygments==2.20.0 --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176' \
+          'python-dateutil==2.9.0.post0 --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427' \
+          'redis==7.4.1 --hash=sha256:1fa4647af1c5e93a2c685aa248ee44cce092691146d41390518dabe9a99839b0' \
+          'six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274' \
+          'wcwidth==0.8.2 --hash=sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85' \
+          > "${workdir}/iredis-requirements.txt"; \
+        pip3 install \
+          --break-system-packages \
+          --disable-pip-version-check \
+          --no-cache-dir \
+          --require-hashes \
+          -r "${workdir}/iredis-requirements.txt"; \
+        rm -rf "${workdir}" ;; \
     esac; \
     printf '%s\n' "${CODE_CLI_VARIANT}" > /etc/code-cli-variant; \
     printf '%s\n' "${TARGETARCH:-unknown}" > /etc/code-cli-arch

--- a/docker_files/code-cli/README.md
+++ b/docker_files/code-cli/README.md
@@ -12,6 +12,7 @@ toolchains are provided as separate variants.
 | `python` | Python, pip, pynvim | `code-cli:python` |
 | `rust` | Rust and Cargo | `code-cli:rust` |
 | `go` | Go | `code-cli:go` |
+| `ops` | Database clients and network diagnostics | `code-cli:ops` |
 
 Every variant includes zsh, tmux, Neovim, bash, git, curl, ripgrep, fd, fzf,
 the configured shell/tmux plugins, Neovim plugins, and precompiled
@@ -30,6 +31,7 @@ bash docker_files/code-cli/build.sh
 VARIANT=python bash docker_files/code-cli/build.sh
 VARIANT=rust bash docker_files/code-cli/build.sh
 VARIANT=go bash docker_files/code-cli/build.sh
+VARIANT=ops bash docker_files/code-cli/build.sh
 
 # custom tag and platform
 PLATFORM=linux/amd64 VARIANT=rust IMAGE=my/code-cli:rust \
@@ -71,6 +73,7 @@ docker run --rm -it code-cli
 docker run --rm -it code-cli:python
 docker run --rm -it code-cli:rust
 docker run --rm -it code-cli:go
+docker run --rm -it code-cli:ops
 ```
 
 Mount a working directory when needed:
@@ -89,18 +92,37 @@ bash docker_files/code-cli/smoke-test.sh code-cli:latest core
 bash docker_files/code-cli/smoke-test.sh code-cli:python python
 bash docker_files/code-cli/smoke-test.sh code-cli:rust rust
 bash docker_files/code-cli/smoke-test.sh code-cli:go go
+bash docker_files/code-cli/smoke-test.sh code-cli:ops ops
 ```
+
+The `ops` variant adds PostgreSQL, Redis, and Kafka clients plus common DNS,
+TCP/UDP, routing, TLS, SSH, JSON, and YAML troubleshooting tools. `kaf` and
+`trippy` are downloaded from pinned upstream releases with architecture-specific
+SHA-256 checksums. IRedis and its Python dependencies are version- and
+hash-pinned in the `ops` build step.
+
+Packet capture and live bandwidth tools are not included in the first version
+because they add substantial image size and generally require `NET_RAW` or
+`NET_ADMIN` capabilities.
 
 ## Size and compatibility trade-offs
 
-Measured locally on `linux/arm64`:
+Measured locally on `linux/arm64` on 2026-07-14:
 
 | Variant | `docker image ls` size | Docker content size |
 | --- | ---: | ---: |
-| `core` | ~243 MB | ~47 MB |
-| `python` | ~321 MB | ~65 MB |
-| `go` | ~735 MB | ~165 MB |
-| `rust` | ~1.02 GB | ~262 MB |
+| `core` | ~165 MB | ~165 MB |
+| `ops` | ~367 MB | ~367 MB |
+
+The `ops` variant is about 202 MB larger than the current `core` image on
+`linux/arm64`. The verified `linux/amd64` image is about 358 MB. The largest
+direct tool payloads are `kaf` (~19 MB), `nmap` (~13 MB), `yq` (~13 MB), and
+`trippy` (~8.6 MB); package dependency sharing means these direct installed
+sizes are not individually additive.
+
+Earlier local measurements for the language variants were ~321 MB for
+`python`, ~735 MB for `go`, and ~1.02 GB for `rust`; Alpine Edge updates can
+change those values between rebuilds.
 
 Language variants are larger than `core` only by the packages required for
 that language. Rust remains the largest because Alpine's Rust package pulls

--- a/docker_files/code-cli/build.sh
+++ b/docker_files/code-cli/build.sh
@@ -16,9 +16,9 @@ VARIANT="${VARIANT:-core}"
 PLATFORM="${PLATFORM:-}"
 
 case "${VARIANT}" in
-  core|python|rust|go) ;;
+  core|python|rust|go|ops) ;;
   *)
-    echo "ERROR: unsupported VARIANT '${VARIANT}' (use core, python, rust, or go)" >&2
+    echo "ERROR: unsupported VARIANT '${VARIANT}' (use core, python, rust, go, or ops)" >&2
     exit 1
     ;;
 esac

--- a/docker_files/code-cli/smoke-test.sh
+++ b/docker_files/code-cli/smoke-test.sh
@@ -6,7 +6,7 @@ IMAGE="${1:-code-cli:latest}"
 EXPECTED_VARIANT="${2:-core}"
 
 case "${EXPECTED_VARIANT}" in
-  core|python|rust|go) ;;
+  core|python|rust|go|ops) ;;
   *)
     echo "ERROR: unsupported expected variant '${EXPECTED_VARIANT}'" >&2
     exit 1
@@ -44,11 +44,18 @@ docker run --rm -t --network none \
     test "${installed_plugins}" = "${expected_plugins}"
     zsh -lic "test \"\${LC_ALL}\" = C.UTF-8"
 
+    assert_ops_commands_absent() {
+      for command in psql redis-cli kcat kaf pgcli iredis ncat socat mtr trip dig nslookup nmap jq yq xh; do
+        ! command -v "${command}" >/dev/null
+      done
+    }
+
     case "${EXPECTED_VARIANT}" in
       core)
         for command in python3 rustc cargo go; do
           ! command -v "${command}" >/dev/null
         done
+        assert_ops_commands_absent
         ;;
       python)
         command -v python3 >/dev/null
@@ -60,6 +67,7 @@ docker run --rm -t --network none \
         for command in rustc cargo go; do
           ! command -v "${command}" >/dev/null
         done
+        assert_ops_commands_absent
         ;;
       rust)
         command -v rustc >/dev/null
@@ -72,6 +80,7 @@ docker run --rm -t --network none \
         for command in python3 go; do
           ! command -v "${command}" >/dev/null
         done
+        assert_ops_commands_absent
         ;;
       go)
         command -v go >/dev/null
@@ -81,6 +90,79 @@ docker run --rm -t --network none \
         "${workdir}/go-smoke"
         rm -rf "${workdir}"
         for command in python3 rustc cargo; do
+          ! command -v "${command}" >/dev/null
+        done
+        assert_ops_commands_absent
+        ;;
+      ops)
+        for command in \
+          psql redis-cli kcat kaf pgcli iredis ncat socat mtr trip dig \
+          nslookup ip ss ping nmap jq yq ssh openssl xh; do
+          command -v "${command}" >/dev/null
+        done
+
+        psql --version
+        redis-cli --version
+        kcat -V
+        kaf --version
+        pgcli --version
+        iredis --version
+        trip --version
+        ncat --version
+        mtr --version
+        nmap --version
+        jq --version
+        yq --version
+        ssh -V
+        openssl version
+        xh --version
+
+        ! timeout 5 psql "postgresql://postgres@127.0.0.1:1/postgres?connect_timeout=1" \
+          -c "select 1"
+        ! timeout 5 redis-cli -u redis://127.0.0.1:1/0 PING
+        ! timeout 5 iredis --url redis://127.0.0.1:1/0 PING
+        ! timeout 5 kcat -b 127.0.0.1:1 -L -m 1
+
+        listener_log="$(mktemp)"
+        socat TCP-LISTEN:45678,bind=127.0.0.1,reuseaddr,fork \
+          OPEN:"${listener_log}",creat,append &
+        listener_pid=$!
+        listener_ready=0
+        for attempt in 1 2 3 4 5; do
+          if ncat -z 127.0.0.1 45678; then
+            listener_ready=1
+            break
+          fi
+          sleep 0.1
+        done
+        test "${listener_ready}" = 1
+        printf "ops-smoke\n" | ncat 127.0.0.1 45678
+        kill "${listener_pid}"
+        wait "${listener_pid}" || true
+        grep -q "ops-smoke" "${listener_log}"
+        rm -f "${listener_log}"
+
+        dns_query="$(mktemp)"
+        socat -u UDP4-RECVFROM:45679,bind=127.0.0.1,reuseaddr STDOUT >"${dns_query}" &
+        dns_listener_pid=$!
+        dns_query_sent=0
+        for attempt in 1 2 3; do
+          if ! dig @127.0.0.1 -p 45679 example.com +time=1 +tries=1 >/dev/null 2>&1 \
+            && test -s "${dns_query}"; then
+            dns_query_sent=1
+            break
+          fi
+        done
+        wait "${dns_listener_pid}"
+        test "${dns_query_sent}" = 1
+        rm -f "${dns_query}"
+
+        nslookup -version
+        mtr --report --report-cycles 1 127.0.0.1
+        trip --mode silent --report-cycles 1 --protocol tcp \
+          --target-port 45679 127.0.0.1
+
+        for command in rustc cargo go; do
           ! command -v "${command}" >/dev/null
         done
         ;;


### PR DESCRIPTION
## 变更

- 新增独立的 `ops` variant，集成 PostgreSQL、Redis、Kafka 客户端及常用网络排障工具
- 为 `kaf`、`trippy` 和 IRedis 依赖固定版本与 SHA-256
- 扩展 smoke test，覆盖命令启动、连接参数、TCP、DNS 和路由诊断
- 验证 `linux/arm64`、`linux/amd64`，并确保现有 variant 不引入 ops 工具

Closes #4